### PR TITLE
unable to use generator functions with different paths

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -67,7 +67,7 @@ module.exports = yeoman.Base.extend({
     },
 
     modulesPath: function() {
-      this.config.set('modulesPath', this.destinationPath('src/modules'));
+      this.config.set('modulesPath', 'src/modules');
     }
   },
 


### PR DESCRIPTION
i started a project as one user on one machine, and now i want to continue as a different user on a different machine.

after cloning my git repo, i was unable to do stuff like `yo duxedo:module test` as the modulesPath had been explicitly set to `/Users/first_user_name/path_to_repository/`

this change replaces the full path with just `src/modules` which allows commands such as the above to be used by different users from the project root, regardless of who the current user was when the project was initially generated.
- [x] change modulesPath template for .yo-rc
